### PR TITLE
@hemartin Rotational Chiper

### DIFF
--- a/rotational-chiper/hemartin/rotational_chiper.go
+++ b/rotational-chiper/hemartin/rotational_chiper.go
@@ -1,0 +1,30 @@
+package rotationalcipher
+
+import (
+	"strings"
+	"unicode"
+)
+
+func RotationalCipher(plain string, shiftKey int) string {
+	var encoded strings.Builder
+	for _, char := range plain {
+		var newChar rune
+
+		if !unicode.IsLetter(char) {
+			newChar = char
+		} else if unicode.IsLower(char) {
+			// Apply the shift and calculate the off limit it is from 'a'
+			// For example, 'z'%'a' = 25, '{'%'a' = 26
+			newShift := (char + rune(shiftKey)) % 'a'
+			// Apply the offset from 'a' reseting it to 0 if 26
+			newChar = 'a' + rune(newShift%26)
+		} else if unicode.IsUpper(char) {
+			newShift := (char + rune(shiftKey)) % 'A'
+			newChar = 'A' + rune(newShift%26)
+		}
+
+		encoded.WriteRune(newChar)
+	}
+
+	return encoded.String()
+}


### PR DESCRIPTION
```
=== RUN   TestRotationalCipher
    rotational_cipher_test.go:76: PASS: rotate a by 0, same output as input
    rotational_cipher_test.go:76: PASS: rotate a by 1
    rotational_cipher_test.go:76: PASS: rotate a by 26, same output as input
    rotational_cipher_test.go:76: PASS: rotate n by 13 with wrap around alphabet
    rotational_cipher_test.go:76: PASS: rotate capital letters
    rotational_cipher_test.go:76: PASS: rotate spaces
    rotational_cipher_test.go:76: PASS: rotate numbers
    rotational_cipher_test.go:76: PASS: rotate punctuation
    rotational_cipher_test.go:76: PASS: rotate all letters
--- PASS: TestRotationalCipher (0.00s)
goos: linux
goarch: amd64
pkg: rotationalcipher
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkRotationalCipher
BenchmarkRotationalCipher-12             1226784               915.2 ns/op           280 B/op         16 allocs/op
PASS
ok      rotationalcipher        2.115s
```