### PR TITLE
lmendes `parsing-log-files` solution

### DIFF
--- a/parsing-log-files/lmendes/parsing_log_files.go
+++ b/parsing-log-files/lmendes/parsing_log_files.go
@@ -1,0 +1,65 @@
+package parsinglogfiles
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const logLineRegexp = `^\[(TRC|DBG|INF|WRN|ERR|FTL)\]\s.*`
+
+func IsValidLine(text string) bool {
+	re := regexp.MustCompile(logLineRegexp)
+	return re.MatchString(text) 
+}
+
+func SplitLogLine(text string) []string {
+	sectionsRe := regexp.MustCompile(`[a-z]+\s\d?`)
+	tagsRe := regexp.MustCompile(`<.*>`)
+	parts := sectionsRe.FindAllString(text, -1)
+	if len(parts) == 0 {
+		parts = tagsRe.FindAllString(text, -1)
+		if len(parts) == 0 {
+			// I had to "cast" the content to an empty string as when "no match" 
+			// the list is empty, not a []string.
+			parts = []string{""}
+		}
+	}
+	return parts
+}
+
+func CountQuotedPasswords(lines []string) int {
+	logLineRegexp := `(?i)\".*password\"`
+	matches := 0
+	re := regexp.MustCompile(logLineRegexp)
+	for _, line := range lines {
+		if (re.MatchString(line)) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func RemoveEndOfLineText(text string) string {
+	eolRegexp := regexp.MustCompile(`end-of-line\d+`)
+	parts := eolRegexp.Split(text, -1)
+	return strings.Join(parts, "")
+}
+
+func TagWithUserName(lines []string) []string {
+	lineRe := regexp.MustCompile(logLineRegexp)
+	userRe := regexp.MustCompile(`User\s+(\w+)`)
+	var taggedLines []string
+	for _, line := range lines {
+		match := lineRe.FindAllString(line, -1)[0]
+		userMatch := userRe.FindAllStringSubmatch(match, -1)
+		if (len(userMatch) != 0) {
+			user := userMatch[0][1]
+		    newLine := fmt.Sprintf("[USR] %s %s", user, match)
+		    taggedLines = append(taggedLines, newLine)
+		} else {
+			taggedLines = append(taggedLines, match)
+		}
+	}
+	return taggedLines
+}


### PR DESCRIPTION
=== RUN   TestIsValidLine
=== RUN   TestIsValidLine/Valid_ERR_message
=== RUN   TestIsValidLine/Valid_INF_message
=== RUN   TestIsValidLine/Invalid_ERR_message
=== RUN   TestIsValidLine/Invalid_INF_message
=== RUN   TestIsValidLine/Invalid_tag
--- PASS: TestIsValidLine (0.00s)
    --- PASS: TestIsValidLine/Valid_ERR_message (0.00s)
    --- PASS: TestIsValidLine/Valid_INF_message (0.00s)
    --- PASS: TestIsValidLine/Invalid_ERR_message (0.00s)
    --- PASS: TestIsValidLine/Invalid_INF_message (0.00s)
    --- PASS: TestIsValidLine/Invalid_tag (0.00s)
=== RUN   TestSplitLogLine
=== RUN   TestSplitLogLine/three_sections
=== RUN   TestSplitLogLine/three_sections_with_different_symbols_inside_angular_brackets
=== RUN   TestSplitLogLine/two_sections_with_no_characters_between_angular_brackets
=== RUN   TestSplitLogLine/single_section_with_some_angular_brackets
=== RUN   TestSplitLogLine/empty_text
--- PASS: TestSplitLogLine (0.00s)
    --- PASS: TestSplitLogLine/three_sections (0.00s)
    --- PASS: TestSplitLogLine/three_sections_with_different_symbols_inside_angular_brackets (0.00s)
    --- PASS: TestSplitLogLine/two_sections_with_no_characters_between_angular_brackets (0.00s)
    --- PASS: TestSplitLogLine/single_section_with_some_angular_brackets (0.00s)
    --- PASS: TestSplitLogLine/empty_text (0.00s)
=== RUN   TestCountQuotedPasswords
=== RUN   TestCountQuotedPasswords/text_with_two_matches
=== RUN   TestCountQuotedPasswords/text_with_no_matches
--- PASS: TestCountQuotedPasswords (0.00s)
    --- PASS: TestCountQuotedPasswords/text_with_two_matches (0.00s)
    --- PASS: TestCountQuotedPasswords/text_with_no_matches (0.00s)
=== RUN   TestRemoveEndOfLineText
=== RUN   TestRemoveEndOfLineText/INF_message
--- PASS: TestRemoveEndOfLineText (0.00s)
    --- PASS: TestRemoveEndOfLineText/INF_message (0.00s)
=== RUN   TestTagWithUserName
=== RUN   TestTagWithUserName/INF_message
--- PASS: TestTagWithUserName (0.00s)
    --- PASS: TestTagWithUserName/INF_message (0.00s)
PASS
ok  	parsinglogfiles	0.002s
