### PR TITLE
skoved parsing-log-files solution

### DIFF
--- a/parsing-log-files/skoved/parsing_log_files.go
+++ b/parsing-log-files/skoved/parsing_log_files.go
@@ -1,0 +1,50 @@
+package parsinglogfiles
+
+import "regexp"
+
+func IsValidLine(text string) bool {
+	const prefix = "^\\[(TRC|DBG|INF|WRN|ERR|FTL)\\]"
+	re := regexp.MustCompile(prefix)
+	return re.MatchString(text)
+}
+
+func SplitLogLine(text string) []string {
+	const split = "<[~*=-]*>"
+	re := regexp.MustCompile(split)
+	// the int is the number of substrings to return. Negative means return all
+	// substrings
+	return re.Split(text, -1)
+}
+
+func CountQuotedPasswords(lines []string) int {
+	count := 0
+	// (?i) at the beginning of the regexp means case insensitive
+	const passwordMatch = "(?i)\".*password.*\""
+	re := regexp.MustCompile(passwordMatch)
+	for _, line := range lines {
+		if re.MatchString(line) {
+			count++
+		}
+	}
+	return count
+}
+
+func RemoveEndOfLineText(text string) string {
+	const endOfLine = "end-of-line\\d+"
+	re := regexp.MustCompile(endOfLine)
+	return re.ReplaceAllString(text, "")
+}
+
+func TagWithUserName(lines []string) []string {
+	const usernameMatch = "User[[:space:]]+(\\S+)\\s"
+	re := regexp.MustCompile(usernameMatch)
+	newLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		subMatch := re.FindStringSubmatch(line)
+		if subMatch != nil && len(subMatch) > 0 {
+			line = "[USR] " + subMatch[1] + " " + line
+		}
+		newLines = append(newLines, line)
+	}
+	return newLines
+}


### PR DESCRIPTION
```
[skoved@fedora parsing-log-files]$ go test -v --bench . --benchmem
=== RUN   TestIsValidLine
=== RUN   TestIsValidLine/Valid_ERR_message
=== RUN   TestIsValidLine/Valid_INF_message
=== RUN   TestIsValidLine/Invalid_ERR_message
=== RUN   TestIsValidLine/Invalid_INF_message
=== RUN   TestIsValidLine/Invalid_tag
--- PASS: TestIsValidLine (0.00s)
    --- PASS: TestIsValidLine/Valid_ERR_message (0.00s)
    --- PASS: TestIsValidLine/Valid_INF_message (0.00s)
    --- PASS: TestIsValidLine/Invalid_ERR_message (0.00s)
    --- PASS: TestIsValidLine/Invalid_INF_message (0.00s)
    --- PASS: TestIsValidLine/Invalid_tag (0.00s)
=== RUN   TestSplitLogLine
=== RUN   TestSplitLogLine/three_sections
=== RUN   TestSplitLogLine/three_sections_with_different_symbols_inside_angular_brackets
=== RUN   TestSplitLogLine/two_sections_with_no_characters_between_angular_brackets
=== RUN   TestSplitLogLine/single_section_with_some_angular_brackets
=== RUN   TestSplitLogLine/empty_text
--- PASS: TestSplitLogLine (0.00s)
    --- PASS: TestSplitLogLine/three_sections (0.00s)
    --- PASS: TestSplitLogLine/three_sections_with_different_symbols_inside_angular_brackets (0.00s)
    --- PASS: TestSplitLogLine/two_sections_with_no_characters_between_angular_brackets (0.00s)
    --- PASS: TestSplitLogLine/single_section_with_some_angular_brackets (0.00s)
    --- PASS: TestSplitLogLine/empty_text (0.00s)
=== RUN   TestCountQuotedPasswords
=== RUN   TestCountQuotedPasswords/text_with_two_matches
=== RUN   TestCountQuotedPasswords/text_with_no_matches
--- PASS: TestCountQuotedPasswords (0.00s)
    --- PASS: TestCountQuotedPasswords/text_with_two_matches (0.00s)
    --- PASS: TestCountQuotedPasswords/text_with_no_matches (0.00s)
=== RUN   TestRemoveEndOfLineText
=== RUN   TestRemoveEndOfLineText/INF_message
--- PASS: TestRemoveEndOfLineText (0.00s)
    --- PASS: TestRemoveEndOfLineText/INF_message (0.00s)
=== RUN   TestTagWithUserName
=== RUN   TestTagWithUserName/INF_message
--- PASS: TestTagWithUserName (0.00s)
    --- PASS: TestTagWithUserName/INF_message (0.00s)
PASS
ok  	parsinglogfiles	0.002s
```