### PR TITLE
@hemartin markdown

### DIFF
--- a/markdown/hemartin/markdown.go
+++ b/markdown/hemartin/markdown.go
@@ -1,0 +1,49 @@
+package markdown
+
+// implementation to refactor
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	headerRegexp    = regexp.MustCompile(`^(#+)[[:blank:]](.*)`)
+	listItemRegexp  = regexp.MustCompile(`(?m:^\*[[:blank:]].*$)`)
+	listRegexp      = regexp.MustCompile(`(?s:<li>.*</li>)`)
+	paragraphRegexp = regexp.MustCompile(`(\n?)([^\n]+)(\n?)`)
+)
+
+// Render translates markdown to HTML
+func Render(markdown string) string {
+	markdown = strings.Replace(markdown, "__", "<strong>", 1)
+	markdown = strings.Replace(markdown, "__", "</strong>", 1)
+	markdown = strings.Replace(markdown, "_", "<em>", 1)
+	markdown = strings.Replace(markdown, "_", "</em>", 1)
+
+	markdown = headerRegexp.ReplaceAllStringFunc(markdown, func(s string) string {
+		headerLevel := strings.Count(s, "#")
+		s = strings.Trim(strings.Replace(s, "#", "", -1), " ")
+		return fmt.Sprintf("<h%d>%s</h%d>", headerLevel, s, headerLevel)
+	})
+
+	markdown = listItemRegexp.ReplaceAllStringFunc(markdown, func(s string) string {
+		s = strings.Replace(s, "* ", "", -1)
+		return fmt.Sprintf("<li>%s</li>", s)
+	})
+
+	markdown = listRegexp.ReplaceAllStringFunc(markdown, func(s string) string {
+		return fmt.Sprintf("<ul>%s</ul>", s)
+	})
+
+	markdown = paragraphRegexp.ReplaceAllStringFunc(markdown, func(s string) string {
+		if strings.HasPrefix(s, "<h") || strings.HasPrefix(s, "<ul") || strings.HasPrefix(s, "<li") {
+			return s
+		}
+		return fmt.Sprintf("<p>%s</p>", s)
+	})
+
+	markdown = strings.ReplaceAll(markdown, "\n", "")
+	return markdown
+}


### PR DESCRIPTION
Before ![profile002](https://user-images.githubusercontent.com/87312991/168016401-2c01a900-03df-42d0-a44e-956c74fde43b.png)

```
[hemartin@hemartin markdown]$ go test -v --bench . --benchmem -cpuprofile=cpu.prof
=== RUN   TestMarkdown
    markdown_test.go:10: PASS: parses normal text as a paragraph
    markdown_test.go:10: PASS: parsing italics
    markdown_test.go:10: PASS: parsing bold text
    markdown_test.go:10: PASS: mixed normal, italics and bold text
    markdown_test.go:10: PASS: with h1 header level
    markdown_test.go:10: PASS: with h2 header level
    markdown_test.go:10: PASS: with h6 header level
    markdown_test.go:10: PASS: unordered lists
    markdown_test.go:10: PASS: With a little bit of everything
--- PASS: TestMarkdown (0.00s)
goos: linux
goarch: amd64
pkg: markdown
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkMarkdown
BenchmarkMarkdown-12    	   72474	     24049 ns/op	    8966 B/op	     531 allocs/op
PASS
ok  	markdown	2.019s
```

After ![profile001](https://user-images.githubusercontent.com/87312991/168016076-2a3613c7-8759-4f97-9e98-e70ae0807c8c.png)


```
[hemartin@hemartin markdown]$ go test -v --bench . --benchmem -cpuprofile=cpu.prof
=== RUN   TestMarkdown
    markdown_test.go:10: PASS: parses normal text as a paragraph
    markdown_test.go:10: PASS: parsing italics
    markdown_test.go:10: PASS: parsing bold text
    markdown_test.go:10: PASS: mixed normal, italics and bold text
    markdown_test.go:10: PASS: with h1 header level
    markdown_test.go:10: PASS: with h2 header level
    markdown_test.go:10: PASS: with h6 header level
    markdown_test.go:10: PASS: unordered lists
    markdown_test.go:10: PASS: With a little bit of everything
--- PASS: TestMarkdown (0.00s)
goos: linux
goarch: amd64
pkg: markdown
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkMarkdown
BenchmarkMarkdown-12               45733             26315 ns/op            5785 B/op        170 allocs/op
PASS
ok      markdown        1.614s
[hemartin@hemartin markdown]$ go tool pprof -png cpu.prof
```