### PR TITLE
manferna space-age solution

### DIFF
--- a/space-age/manferna/space_age.go
+++ b/space-age/manferna/space_age.go
@@ -1,0 +1,26 @@
+package space
+
+type Planet string
+
+func Age(seconds float64, planet Planet) float64 {
+	const EarthInSeconds = 31557600
+
+	orbitalPeriods := map[Planet]float64{
+		"Mercury": 0.2408467,
+		"Venus":   0.61519726,
+		"Earth":   1.0,
+		"Mars":    1.8808158,
+		"Jupiter": 11.862615,
+		"Saturn":  29.447498,
+		"Uranus":  84.016846,
+		"Neptune": 164.79132,
+	}
+
+	yearsInSeconds := map[Planet]float64{}
+	var yearInSecond float64
+	for planet, orbitalPeriod := range orbitalPeriods {
+		yearInSecond = EarthInSeconds * orbitalPeriod
+		yearsInSeconds[planet] = yearInSecond
+	}
+	return seconds / yearsInSeconds[planet]
+}


### PR DESCRIPTION
[manferna@manferna space-age]$ go test -v --bench . --benchmem
=== RUN   TestAge
    space_age_test.go:15: PASS: age on Earth
    space_age_test.go:15: PASS: age on Mercury
    space_age_test.go:15: PASS: age on Venus
    space_age_test.go:15: PASS: age on Mars
    space_age_test.go:15: PASS: age on Jupiter
    space_age_test.go:15: PASS: age on Saturn
    space_age_test.go:15: PASS: age on Uranus
    space_age_test.go:15: PASS: age on Neptune
--- PASS: TestAge (0.00s)
goos: linux
goarch: amd64
pkg: space
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkAge
BenchmarkAge-12           377797              2898 ns/op               0 B/op          0 allocs/op
PASS
ok      space   1.129s