### PR TITLE
skoved bank-account solution

### DIFF
--- a/bank-account/skoved/bank_account.go
+++ b/bank-account/skoved/bank_account.go
@@ -1,0 +1,57 @@
+package account
+
+import (
+	"sync"
+)
+
+// Define the Account type here.
+type Account struct {
+	mu      sync.RWMutex
+	balance int64
+	closed  bool
+}
+
+func Open(amount int64) *Account {
+	if amount < 0 {
+		return nil
+	}
+
+	return &Account{
+		balance: amount,
+	}
+}
+
+func (a *Account) Balance() (int64, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.closed {
+		return 0, false
+	}
+	return a.balance, true
+}
+
+func (a *Account) Deposit(amount int64) (int64, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed || a.balance+amount < 0 {
+		return 0, false
+	}
+	a.balance += amount
+	return a.balance, true
+}
+
+func (a *Account) Close() (int64, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return 0, false
+	}
+
+	balance := a.balance
+	a.balance = 0
+	a.closed = true
+	return balance, true
+}


### PR DESCRIPTION
```
[skoved@dhcp-89-144 bank-account]$ go test -v --bench . --benchmem
=== RUN   TestSeqOpenBalanceClose
    bank_account_test.go:18: Account 'a' opened with initial balance of 10.
    bank_account_test.go:35: Account 'a' closed.
--- PASS: TestSeqOpenBalanceClose (0.00s)
=== RUN   TestSeqOpenDepositClose
    bank_account_test.go:57: Account 'a' opened with initial balance of 10.
    bank_account_test.go:68: Deposit of 20 accepted to account 'a'
    bank_account_test.go:77: Account 'a' closed.
--- PASS: TestSeqOpenDepositClose (0.00s)
=== RUN   TestMoreSeqCases
    bank_account_test.go:93: Account 'a' opened with initial balance of 10.
    bank_account_test.go:100: Account 'z' opened with initial balance of 0.
    bank_account_test.go:131: Withdrawal of 3 accepted from account 'a'
    bank_account_test.go:157: Account 'z' closed.
--- PASS: TestMoreSeqCases (0.00s)
=== RUN   TestConcClose
--- PASS: TestConcClose (0.01s)
=== RUN   TestConcDeposit
--- PASS: TestConcDeposit (0.01s)
goos: linux
goarch: amd64
pkg: account
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkAccountOperations
BenchmarkAccountOperations-12            	20523970	        57.89 ns/op	       0 B/op	       0 allocs/op
BenchmarkAccountOperationsParallel
BenchmarkAccountOperationsParallel-12    	 8215410	       129.1 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	account	2.474s
```