### PR TITLE
skoved minesweeper solution

### DIFF
--- a/minesweeper/skoved/minesweeper.go
+++ b/minesweeper/skoved/minesweeper.go
@@ -1,0 +1,107 @@
+package minesweeper
+
+import (
+	"fmt"
+	"strings"
+)
+
+const mine = '*'
+
+type tile struct {
+	mine      bool
+	mineCount uint
+}
+
+func (t tile) String() string {
+	if t.mine {
+		return string(mine)
+	}
+	if t.mineCount == 0 {
+		return " "
+	}
+	return fmt.Sprintf("%d", t.mineCount)
+}
+
+// increments the mineCount of the tile if the tile does not have a mine
+func (t *tile) incMineCount() {
+	if !t.mine {
+		t.mineCount++
+	}
+}
+
+// return a sequence of ints from start to end. Sequence will always start at zero and end at length - 1
+func makeRange(start, end, length int) []int {
+	if start < 0 {
+		start = 0
+	}
+	if end >= length {
+		end = length - 1
+	}
+	if start > end {
+		panic("Start cannot be greater than end")
+	}
+
+	newRange := make([]int, end-start+1)
+	for i := range newRange {
+		newRange[i] = start + i
+	}
+	return newRange
+}
+
+func incTiles(board [][]tile, rowRange, colRange []int) {
+	for _, rowNum := range rowRange {
+		for _, colNum := range colRange {
+			board[rowNum][colNum].incMineCount()
+		}
+	}
+}
+
+// Annotate returns an annotated board
+func Annotate(board []string) []string {
+	length := len(board)
+
+	// short circuit for empty boards
+	if length == 0 {
+		return []string{}
+	}
+	if board[0] == "" {
+		return []string{""}
+	}
+
+	// create board with tiles
+	transform := make([][]tile, length)
+	for i, row := range board {
+		transform[i] = make([]tile, len(row))
+	}
+
+	// add mines to new board
+	for rowNum, row := range board {
+		for colNum, space := range row {
+			if space == mine {
+				transform[rowNum][colNum].mine = true
+			}
+		}
+	}
+
+	for rowNum, row := range board {
+		for colNum, space := range row {
+			if space == mine {
+				rowRange := makeRange(rowNum-1, rowNum+1, length)
+				colRange := makeRange(colNum-1, colNum+1, len(row))
+				incTiles(transform, rowRange, colRange)
+			}
+		}
+	}
+
+	// convert transform to []string
+	markedBoard := make([]string, length)
+	for rowNum, row := range transform {
+		var builder strings.Builder
+		builder.Grow(len(row))
+		for _, space := range row {
+			builder.WriteString(fmt.Sprintf("%v", space))
+		}
+		markedBoard[rowNum] = builder.String()
+	}
+	return markedBoard
+}


### PR DESCRIPTION
```
 $ go test -v --bench . --benchmem
=== RUN   TestAnnotate
=== RUN   TestAnnotate/no_rows
=== RUN   TestAnnotate/no_columns
=== RUN   TestAnnotate/no_mines
=== RUN   TestAnnotate/minefield_with_only_mines
=== RUN   TestAnnotate/mine_surrounded_by_spaces
=== RUN   TestAnnotate/space_surrounded_by_mines
=== RUN   TestAnnotate/horizontal_line
=== RUN   TestAnnotate/horizontal_line,_mines_at_edges
=== RUN   TestAnnotate/vertical_line
=== RUN   TestAnnotate/vertical_line,_mines_at_edges
=== RUN   TestAnnotate/cross
=== RUN   TestAnnotate/large_minefield
--- PASS: TestAnnotate (0.00s)
    --- PASS: TestAnnotate/no_rows (0.00s)
    --- PASS: TestAnnotate/no_columns (0.00s)
    --- PASS: TestAnnotate/no_mines (0.00s)
    --- PASS: TestAnnotate/minefield_with_only_mines (0.00s)
    --- PASS: TestAnnotate/mine_surrounded_by_spaces (0.00s)
    --- PASS: TestAnnotate/space_surrounded_by_mines (0.00s)
    --- PASS: TestAnnotate/horizontal_line (0.00s)
    --- PASS: TestAnnotate/horizontal_line,_mines_at_edges (0.00s)
    --- PASS: TestAnnotate/vertical_line (0.00s)
    --- PASS: TestAnnotate/vertical_line,_mines_at_edges (0.00s)
    --- PASS: TestAnnotate/cross (0.00s)
    --- PASS: TestAnnotate/large_minefield (0.00s)
goos: linux
goarch: amd64
pkg: minesweeper
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkAnnotate
BenchmarkAnnotate-12    	  126766	      9203 ns/op	    1800 B/op	      66 allocs/op
PASS
ok  	minesweeper	1.266s
```